### PR TITLE
config: add gitattributes to enforce uniform line endings

### DIFF
--- a/backend/.gitattributes
+++ b/backend/.gitattributes
@@ -1,0 +1,7 @@
+# Enforce Unix-style line endings for all text files
+* text=auto eol=lf
+
+# Binary files should not have line endings normalized
+*.bin binary
+*.png binary
+*.jpg binary


### PR DESCRIPTION
Dodany plik gitattributes z konfiguracją kodowania znaków nowej linii, żeby commitowane pliki zawsze używaly LF (linux/macOS). Dzięki temu można uniknąć dziwnych blędów oraz w code review nie będzie problemu z niepotrzebnym i nadmiernym pokazywaniem "zmian" (plik utworzony/zapisany na linux i wrzucony na repo, a potem otwarty i zapisany na windowsie móglby bez tego pliku gitattributes pokazywać się w code review jako caly zmieniony, bo wszystkie znaki końca linii by się zmienily)