### PR TITLE
config: add prettier for uniform frontend code formatting

### DIFF
--- a/frontend/.prettierrc
+++ b/frontend/.prettierrc
@@ -1,0 +1,9 @@
+{
+  "printWidth": 88,
+  "tabWidth": 2,
+  "useTabs": false,
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "none",
+  "bracketSpacing": true
+}


### PR DESCRIPTION
Dodany plik konfiguracyjny .prettierrc do projektu frontendowego. Określa on reguly formatowania kodu frontendowego. Można go zintegrować np. z vscode (poprzez wtyczkę prettier) lub z git hookami, żeby wymusić jednolite formatowanie kodu html/ts/js/css/scss.

Myślę, że warto zaimplementować takie narzędzie, bo:
1. Oszczędza w zupelności potrzebę formatowania lokalnie kodu 
2. Jeżeli zintegrować je z git hookami/cicd, możemy wyeliminować problem wrzucania źle sformatowanego kodu na repo. Bez tego, jeżeli ktoś ma skonfigurowane automatyczne formatowanie kodu, a na repo jest źle sformatowany kod, to przy pracy na takich plikach lokalnie uruchamia się formatowanie -> w code review pokazuje się więcej zmian, które tak naprawdę są tylko zmianami formatowania -> robi się śmietnik i code review jest znacznie utrudnione