### PR TITLE
config: add proxy.conf with local configuration

### DIFF
--- a/frontend/angular.json
+++ b/frontend/angular.json
@@ -57,6 +57,9 @@
         },
         "serve": {
           "builder": "@angular/build:dev-server",
+          "options": {
+            "proxyConfig": "proxy.conf.json"
+          },
           "configurations": {
             "production": {
               "buildTarget": "frontend:build:production"

--- a/frontend/proxy.conf.json
+++ b/frontend/proxy.conf.json
@@ -1,0 +1,9 @@
+{
+  "/api": {
+    "target": "http://localhost:8080",
+    "secure": false,
+    "changeOrigin": true,
+    "logLevel": "debug"
+  }
+}
+


### PR DESCRIPTION
W odniesieniu do: https://github.com/ProjectZero951/angular-dotnet-starter/issues/29

Dodany proxy.conf do lokalnego developmentu. requesty do /api są forwardowane do http://localhost:8080 api, dzięki czemu dla przeglądarki komunikacja frontend-backend odbywa się na jednym originie - nie potrzeba CORS.

Eliminuje to potrzebę dodawania localhostów do konfiguracji CORS serwera aplikacji. 